### PR TITLE
[REFACTOR/FEAT] 유저 조회 리팩토링 & 예외처리 추가

### DIFF
--- a/src/main/java/com/muji_backend/kw_muji/survey/controller/MySurveyController.java
+++ b/src/main/java/com/muji_backend/kw_muji/survey/controller/MySurveyController.java
@@ -1,10 +1,12 @@
 package com.muji_backend.kw_muji.survey.controller;
 
+import com.muji_backend.kw_muji.common.entity.UserEntity;
 import com.muji_backend.kw_muji.survey.dto.response.MySurveyResponseDto;
 import com.muji_backend.kw_muji.survey.dto.response.MySurveyResultResponseDto;
 import com.muji_backend.kw_muji.survey.service.MySurveyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -17,10 +19,10 @@ public class MySurveyController {
 
     private final MySurveyService mySurveyService;
 
-    @GetMapping("/{userId}")
-    public ResponseEntity<?> getMySurveys(@PathVariable Long userId) {
+    @GetMapping
+    public ResponseEntity<?> getMySurveys(@AuthenticationPrincipal UserEntity userInfo) {
         try {
-            List<MySurveyResponseDto> surveys = mySurveyService.getSurveysByUserId(userId);
+            List<MySurveyResponseDto> surveys = mySurveyService.getSurveysByUserId(userInfo.getId());
             return ResponseEntity.ok().body(Map.of("code", 200, "data", surveys));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(Map.of("code", 400, "message", e.getMessage()));

--- a/src/main/java/com/muji_backend/kw_muji/survey/controller/SurveyController.java
+++ b/src/main/java/com/muji_backend/kw_muji/survey/controller/SurveyController.java
@@ -63,10 +63,11 @@ public class SurveyController {
 
     @PostMapping("/submit/{surveyId}")
     public ResponseEntity<?> submitSurvey(
+            @AuthenticationPrincipal UserEntity userInfo,
             @PathVariable Long surveyId,
             @RequestBody SurveySubmitRequestDto requestDto) {
         try {
-            Long responseId = surveySubmitService.submitSurvey(surveyId, requestDto);
+            Long responseId = surveySubmitService.submitSurvey(userInfo.getId(), surveyId, requestDto);
             return ResponseEntity.ok().body(Map.of("code", 200, "responseId", responseId));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(Map.of("code", 400, "message", e.getMessage()));

--- a/src/main/java/com/muji_backend/kw_muji/survey/controller/SurveyController.java
+++ b/src/main/java/com/muji_backend/kw_muji/survey/controller/SurveyController.java
@@ -1,5 +1,6 @@
 package com.muji_backend.kw_muji.survey.controller;
 
+import com.muji_backend.kw_muji.common.entity.UserEntity;
 import com.muji_backend.kw_muji.survey.dto.request.SurveyRequestDto;
 import com.muji_backend.kw_muji.survey.dto.request.SurveySubmitRequestDto;
 import com.muji_backend.kw_muji.survey.dto.response.SurveyDetailResponseDto;
@@ -9,6 +10,7 @@ import com.muji_backend.kw_muji.survey.service.SurveyService;
 import com.muji_backend.kw_muji.survey.service.SurveySubmitService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -35,10 +37,10 @@ public class SurveyController {
         }
     }
 
-    @PostMapping("/create/{userId}")
-    public ResponseEntity<?> createSurvey(@PathVariable Long userId, @RequestBody SurveyRequestDto requestDto) {
+    @PostMapping("/create")
+    public ResponseEntity<?> createSurvey(@AuthenticationPrincipal UserEntity userInfo, @RequestBody SurveyRequestDto requestDto) {
         try {
-            Long surveyId = surveyCreateService.createSurvey(userId, requestDto);
+            Long surveyId = surveyCreateService.createSurvey(userInfo.getId(), requestDto);
             return ResponseEntity.ok().body(Map.of("code", 200, "surveyId", surveyId));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(Map.of("code", 400, "message", e.getMessage()));

--- a/src/main/java/com/muji_backend/kw_muji/survey/controller/SurveyController.java
+++ b/src/main/java/com/muji_backend/kw_muji/survey/controller/SurveyController.java
@@ -69,6 +69,8 @@ public class SurveyController {
         try {
             Long responseId = surveySubmitService.submitSurvey(userInfo.getId(), surveyId, requestDto);
             return ResponseEntity.ok().body(Map.of("code", 200, "responseId", responseId));
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(409).body(Map.of("code", 409, "message", e.getMessage()));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(Map.of("code", 400, "message", e.getMessage()));
         } catch (Exception e) {

--- a/src/main/java/com/muji_backend/kw_muji/survey/dto/request/SurveySubmitRequestDto.java
+++ b/src/main/java/com/muji_backend/kw_muji/survey/dto/request/SurveySubmitRequestDto.java
@@ -12,7 +12,6 @@ import java.util.List;
 @NoArgsConstructor
 @Builder
 public class SurveySubmitRequestDto {
-    private Long userId;
     private List<AnswerDto> answers;
 
     @Data

--- a/src/main/java/com/muji_backend/kw_muji/survey/repository/ResponseRepository.java
+++ b/src/main/java/com/muji_backend/kw_muji/survey/repository/ResponseRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 @Repository
 public interface ResponseRepository extends JpaRepository<ResponseEntity, Long> {
     List<ResponseEntity> findBySurveyId(Long surveyId);
+    boolean existsByUsersIdAndSurveyId(Long userId, Long surveyId);
 }

--- a/src/main/java/com/muji_backend/kw_muji/survey/service/SurveySubmitService.java
+++ b/src/main/java/com/muji_backend/kw_muji/survey/service/SurveySubmitService.java
@@ -41,6 +41,10 @@ public class SurveySubmitService {
         SurveyEntity survey = findSurveyById(surveyId);
         UserEntity user = findUserById(userId);
 
+        if (!survey.isOngoing()) {
+            throw new IllegalStateException("설문 기간이 종료된 설문입니다.: " + surveyId);
+        }
+
         // 응답을 저장
         ResponseEntity response = createAndSaveResponse(survey, user);
 

--- a/src/main/java/com/muji_backend/kw_muji/survey/service/SurveySubmitService.java
+++ b/src/main/java/com/muji_backend/kw_muji/survey/service/SurveySubmitService.java
@@ -32,6 +32,11 @@ public class SurveySubmitService {
      * @return 저장된 응답 ID
      */
     public Long submitSurvey(Long userId, Long surveyId, SurveySubmitRequestDto requestDto) {
+        // 이미 설문에 응답한 경우
+        if (responseRepository.existsByUsersIdAndSurveyId(userId, surveyId)) {
+            throw new IllegalStateException("이미 설문에 참여한 유저입니다.: " + userId);
+        }
+
         // 설문과 사용자 정보를 가져옴
         SurveyEntity survey = findSurveyById(surveyId);
         UserEntity user = findUserById(userId);

--- a/src/main/java/com/muji_backend/kw_muji/survey/service/SurveySubmitService.java
+++ b/src/main/java/com/muji_backend/kw_muji/survey/service/SurveySubmitService.java
@@ -31,10 +31,10 @@ public class SurveySubmitService {
      * @param requestDto 설문 응답 데이터
      * @return 저장된 응답 ID
      */
-    public Long submitSurvey(Long surveyId, SurveySubmitRequestDto requestDto) {
+    public Long submitSurvey(Long userId, Long surveyId, SurveySubmitRequestDto requestDto) {
         // 설문과 사용자 정보를 가져옴
         SurveyEntity survey = findSurveyById(surveyId);
-        UserEntity user = findUserById(requestDto.getUserId());
+        UserEntity user = findUserById(userId);
 
         // 응답을 저장
         ResponseEntity response = createAndSaveResponse(survey, user);


### PR DESCRIPTION
1. 기존의 UserId를 받는 것이 아닌, @AuthenticationPrincipal로 유저정보 조회하도록 리팩토링
2. 설문 참여 가능 여부 예외처리: 이미 종료된 설문 & 이미 설문에 참여한 유저 -> 설문 참여 불가능

close: #46 