### PR TITLE
feat: 캘린더 메인 페이지 일정 조회 기능

### DIFF
--- a/src/main/java/com/muji_backend/kw_muji/calendar/controller/CalendarController.java
+++ b/src/main/java/com/muji_backend/kw_muji/calendar/controller/CalendarController.java
@@ -1,0 +1,34 @@
+package com.muji_backend.kw_muji.calendar.controller;
+
+import com.muji_backend.kw_muji.calendar.service.CalendarService;
+import com.muji_backend.kw_muji.common.entity.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/calendar")
+public class CalendarController {
+
+    private final CalendarService calendarService;
+
+    @GetMapping("/{yearMonth}")
+    public ResponseEntity<?> getCalendar(@AuthenticationPrincipal UserEntity userInfo,
+                                                           @PathVariable String yearMonth) {
+        try {
+
+            return ResponseEntity.ok().body(Map.of("code", 200, "data", response));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("code", 400, "message", e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(Map.of("code", 500, "message", e.getMessage()));
+        }
+    }
+}

--- a/src/main/java/com/muji_backend/kw_muji/calendar/controller/CalendarController.java
+++ b/src/main/java/com/muji_backend/kw_muji/calendar/controller/CalendarController.java
@@ -24,7 +24,7 @@ public class CalendarController {
     public ResponseEntity<?> getCalendar(@AuthenticationPrincipal UserEntity userInfo,
                                          @PathVariable String yearMonth) {
         try {
-            CalendarResponseDto response = calendarService.getCalendarEvents(userInfo.getId(), yearMonth);
+            CalendarResponseDto response = calendarService.getCalendarEvents(userInfo, yearMonth);
             return ResponseEntity.ok().body(Map.of("code", 200, "data", response));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(Map.of("code", 400, "message", e.getMessage()));

--- a/src/main/java/com/muji_backend/kw_muji/calendar/controller/CalendarController.java
+++ b/src/main/java/com/muji_backend/kw_muji/calendar/controller/CalendarController.java
@@ -1,5 +1,6 @@
 package com.muji_backend.kw_muji.calendar.controller;
 
+import com.muji_backend.kw_muji.calendar.dto.response.CalendarResponseDto;
 import com.muji_backend.kw_muji.calendar.service.CalendarService;
 import com.muji_backend.kw_muji.common.entity.UserEntity;
 import lombok.RequiredArgsConstructor;
@@ -21,9 +22,9 @@ public class CalendarController {
 
     @GetMapping("/{yearMonth}")
     public ResponseEntity<?> getCalendar(@AuthenticationPrincipal UserEntity userInfo,
-                                                           @PathVariable String yearMonth) {
+                                         @PathVariable String yearMonth) {
         try {
-
+            CalendarResponseDto response = calendarService.getCalendarEvents(userInfo.getId(), yearMonth);
             return ResponseEntity.ok().body(Map.of("code", 200, "data", response));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(Map.of("code", 400, "message", e.getMessage()));

--- a/src/main/java/com/muji_backend/kw_muji/calendar/dto/response/CalendarResponseDto.java
+++ b/src/main/java/com/muji_backend/kw_muji/calendar/dto/response/CalendarResponseDto.java
@@ -1,0 +1,58 @@
+package com.muji_backend.kw_muji.calendar.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class CalendarResponseDto {
+
+    private List<ProjectDto> projects;
+    private EventGroup events;
+
+    @Data
+    @AllArgsConstructor
+    public static class ProjectDto {
+        private long projectId;
+        private String name;
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class EventGroup {
+        private List<UnivEventDto> univEvents;
+        private List<UserEventDto> userEvents;
+        private List<ProjectEventDto> projectEvents;
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class UnivEventDto {
+        private long univcalendarId;
+        private String title;
+        private LocalDate eventDate;
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class UserEventDto {
+        private long usercalendarId;
+        private String title;
+        private LocalDateTime eventDate;
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class ProjectEventDto {
+        private long usercalendarId;
+        private long projectId;
+        private String title;
+        private LocalDateTime eventDate;
+    }
+}

--- a/src/main/java/com/muji_backend/kw_muji/calendar/repository/ParticipationRepository.java
+++ b/src/main/java/com/muji_backend/kw_muji/calendar/repository/ParticipationRepository.java
@@ -1,0 +1,15 @@
+package com.muji_backend.kw_muji.calendar.repository;
+
+import com.muji_backend.kw_muji.common.entity.ParticipationEntity;
+import com.muji_backend.kw_muji.common.entity.UserEntity;
+import com.muji_backend.kw_muji.common.entity.enums.ProjectRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ParticipationRepository extends JpaRepository<ParticipationEntity, Long> {
+    // 유저가 참여 중인 프로젝트를 조회 (Role이 CREATOR 또는 MEMBER인 경우, 그리고 프로젝트 시작 값이 true인 경우)
+    List<ParticipationEntity> findAllByUsersAndRoleInAndProjectStartTrue(UserEntity user, List<ProjectRole> roles);
+}

--- a/src/main/java/com/muji_backend/kw_muji/calendar/repository/UnivCalendarRepository.java
+++ b/src/main/java/com/muji_backend/kw_muji/calendar/repository/UnivCalendarRepository.java
@@ -1,9 +1,14 @@
 package com.muji_backend.kw_muji.calendar.repository;
 
 import com.muji_backend.kw_muji.common.entity.UnivCalendarEntity;
+import com.muji_backend.kw_muji.common.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Repository
 public interface UnivCalendarRepository extends JpaRepository<UnivCalendarEntity, Long> {
-}
+    // 대학 일정 조회
+    List<UnivCalendarEntity> findAllByUsersAndEventDateBetween(UserEntity user, LocalDateTime startDate, LocalDateTime endDate);}

--- a/src/main/java/com/muji_backend/kw_muji/calendar/repository/UnivCalendarRepository.java
+++ b/src/main/java/com/muji_backend/kw_muji/calendar/repository/UnivCalendarRepository.java
@@ -1,0 +1,9 @@
+package com.muji_backend.kw_muji.calendar.repository;
+
+import com.muji_backend.kw_muji.common.entity.UnivCalendarEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UnivCalendarRepository extends JpaRepository<UnivCalendarEntity, Long> {
+}

--- a/src/main/java/com/muji_backend/kw_muji/calendar/repository/UserCalendarRepository.java
+++ b/src/main/java/com/muji_backend/kw_muji/calendar/repository/UserCalendarRepository.java
@@ -1,9 +1,19 @@
 package com.muji_backend.kw_muji.calendar.repository;
 
+import com.muji_backend.kw_muji.common.entity.ProjectEntity;
 import com.muji_backend.kw_muji.common.entity.UserCalendarEntity;
+import com.muji_backend.kw_muji.common.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Repository
 public interface UserCalendarRepository extends JpaRepository<UserCalendarEntity, Long> {
+    // 개인 일정 조회 (projectId가 null인 경우)
+    List<UserCalendarEntity> findAllByUsersAndProjectIsNullAndEventDateBetween(UserEntity user, LocalDateTime startDate, LocalDateTime endDate);
+
+    // 프로젝트 일정 조회 (projectId가 존재하는 경우)
+    List<UserCalendarEntity> findAllByProjectAndEventDateBetween(ProjectEntity project, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/muji_backend/kw_muji/calendar/repository/UserCalendarRepository.java
+++ b/src/main/java/com/muji_backend/kw_muji/calendar/repository/UserCalendarRepository.java
@@ -1,0 +1,9 @@
+package com.muji_backend.kw_muji.calendar.repository;
+
+import com.muji_backend.kw_muji.common.entity.UserCalendarEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserCalendarRepository extends JpaRepository<UserCalendarEntity, Long> {
+}

--- a/src/main/java/com/muji_backend/kw_muji/calendar/repository/UserCalendarRepository.java
+++ b/src/main/java/com/muji_backend/kw_muji/calendar/repository/UserCalendarRepository.java
@@ -14,6 +14,6 @@ public interface UserCalendarRepository extends JpaRepository<UserCalendarEntity
     // 개인 일정 조회 (projectId가 null인 경우)
     List<UserCalendarEntity> findAllByUsersAndProjectIsNullAndEventDateBetween(UserEntity user, LocalDateTime startDate, LocalDateTime endDate);
 
-    // 프로젝트 일정 조회 (projectId가 존재하는 경우)
-    List<UserCalendarEntity> findAllByProjectAndEventDateBetween(ProjectEntity project, LocalDateTime startDate, LocalDateTime endDate);
+    // 프로젝트 일정 조회 (projectId가 있는 경우 / 프로젝트 리스트와 날짜 범위에 따라 일정 조회)
+    List<UserCalendarEntity> findAllByProjectInAndEventDateBetween(List<ProjectEntity> projects, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/muji_backend/kw_muji/calendar/service/CalendarService.java
+++ b/src/main/java/com/muji_backend/kw_muji/calendar/service/CalendarService.java
@@ -1,0 +1,7 @@
+package com.muji_backend.kw_muji.calendar.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class CalendarService {
+}

--- a/src/main/java/com/muji_backend/kw_muji/calendar/service/CalendarService.java
+++ b/src/main/java/com/muji_backend/kw_muji/calendar/service/CalendarService.java
@@ -1,7 +1,12 @@
 package com.muji_backend.kw_muji.calendar.service;
 
+import com.muji_backend.kw_muji.calendar.dto.response.CalendarResponseDto;
 import org.springframework.stereotype.Service;
 
 @Service
 public class CalendarService {
+
+    public CalendarResponseDto getCalendarEvents(Long userId, String yearMonth) {
+
+    }
 }

--- a/src/main/java/com/muji_backend/kw_muji/calendar/service/CalendarService.java
+++ b/src/main/java/com/muji_backend/kw_muji/calendar/service/CalendarService.java
@@ -11,7 +11,11 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
+import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -22,26 +26,56 @@ public class CalendarService {
     private final ParticipationRepository participationRepository;
 
     public CalendarResponseDto getCalendarEvents(UserEntity userInfo, String yearMonth) {
-        YearMonth ym = YearMonth.parse(yearMonth); // yyyy-MM 형식
+        if (userInfo == null) {
+            throw new IllegalArgumentException("유저 정보가 필요합니다.");
+        }
+
+        YearMonth ym;
+        try {
+            ym = YearMonth.parse(yearMonth); // yyyy-MM 형식
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("잘못된 날짜 형식입니다. yyyy-MM 형식을 사용해주세요.");
+        }
+
         LocalDateTime startDateTime = ym.atDay(1).atStartOfDay();
         LocalDateTime endDateTime = ym.atEndOfMonth().atTime(23, 59, 59);
 
         // 대학 일정 조회
-        List<UnivCalendarEntity> univEvents = univCalendarRepository.findAllByUsersAndEventDateBetween(userInfo, startDateTime, endDateTime);
+        List<UnivCalendarEntity> univEvents = safeList(() -> univCalendarRepository.findAllByUsersAndEventDateBetween(userInfo, startDateTime, endDateTime));
 
         // 개인 일정 조회 (projectId가 null인 경우)
-        List<UserCalendarEntity> userEvents = userCalendarRepository.findAllByUsersAndProjectIsNullAndEventDateBetween(userInfo, startDateTime, endDateTime);
+        List<UserCalendarEntity> userEvents = safeList(() -> userCalendarRepository.findAllByUsersAndProjectIsNullAndEventDateBetween(userInfo, startDateTime, endDateTime));
 
         // 참여중인 프로젝트 조회 (Role이 CREATOR나 MEMBER인 경우, start 값이 true인 프로젝트)
-        List<ParticipationEntity> participations = participationRepository.findAllByUsersAndRoleInAndProjectStartTrue(userInfo, List.of(ProjectRole.CREATOR, ProjectRole.MEMBER));
-        List<ProjectEntity> projects = participations.stream()
+        List<ProjectEntity> projects = participationRepository.findAllByUsersAndRoleInAndProjectStartTrue(userInfo, List.of(ProjectRole.CREATOR, ProjectRole.MEMBER))
+                .stream()
                 .map(ParticipationEntity::getProject)
                 .toList();
 
         // 참여중인 프로젝트 일정 조회
-        List<UserCalendarEntity> projectEvents = projects.stream()
-                .flatMap(project -> userCalendarRepository.findAllByProjectAndEventDateBetween(project, startDateTime, endDateTime).stream())
-                .toList();
+        List<UserCalendarEntity> projectEvents = safeList(() -> userCalendarRepository.findAllByProjectInAndEventDateBetween(projects, startDateTime, endDateTime));
 
+        return CalendarResponseDto.builder()
+                .projects(projects.stream()
+                        .map(p -> new CalendarResponseDto.ProjectDto(p.getId(),p.getName()))
+                        .collect(Collectors.toList()))
+                .events(new CalendarResponseDto.EventGroup(
+                        univEvents.stream()
+                                .map(e -> new CalendarResponseDto.UnivEventDto(e.getId(), e.getTitle(), e.getEventDate().toLocalDate()))
+                                .collect(Collectors.toList()),
+                        userEvents.stream()
+                                .map(e -> new CalendarResponseDto.UserEventDto(e.getId(), e.getTitle(), e.getEventDate()))
+                                .collect(Collectors.toList()),
+                        projectEvents.stream()
+                                .map(e -> new CalendarResponseDto.ProjectEventDto(e.getId(), e.getProject().getId(), e.getTitle(), e.getEventDate()))
+                                .collect(Collectors.toList())
+                ))
+                .build();
+    }
+
+    // 결과가 null인 경우 빈 리스트 반환
+    private <T> List<T> safeList(Supplier<List<T>> queryFunction) {
+        List<T> result = queryFunction.get();
+        return result != null ? result : Collections.emptyList();
     }
 }

--- a/src/main/java/com/muji_backend/kw_muji/calendar/service/CalendarService.java
+++ b/src/main/java/com/muji_backend/kw_muji/calendar/service/CalendarService.java
@@ -1,12 +1,47 @@
 package com.muji_backend.kw_muji.calendar.service;
 
 import com.muji_backend.kw_muji.calendar.dto.response.CalendarResponseDto;
+import com.muji_backend.kw_muji.calendar.repository.ParticipationRepository;
+import com.muji_backend.kw_muji.calendar.repository.UnivCalendarRepository;
+import com.muji_backend.kw_muji.calendar.repository.UserCalendarRepository;
+import com.muji_backend.kw_muji.common.entity.*;
+import com.muji_backend.kw_muji.common.entity.enums.ProjectRole;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+
 @Service
+@RequiredArgsConstructor
 public class CalendarService {
 
-    public CalendarResponseDto getCalendarEvents(Long userId, String yearMonth) {
+    private final UnivCalendarRepository univCalendarRepository;
+    private final UserCalendarRepository userCalendarRepository;
+    private final ParticipationRepository participationRepository;
+
+    public CalendarResponseDto getCalendarEvents(UserEntity userInfo, String yearMonth) {
+        YearMonth ym = YearMonth.parse(yearMonth); // yyyy-MM 형식
+        LocalDateTime startDateTime = ym.atDay(1).atStartOfDay();
+        LocalDateTime endDateTime = ym.atEndOfMonth().atTime(23, 59, 59);
+
+        // 대학 일정 조회
+        List<UnivCalendarEntity> univEvents = univCalendarRepository.findAllByUsersAndEventDateBetween(userInfo, startDateTime, endDateTime);
+
+        // 개인 일정 조회 (projectId가 null인 경우)
+        List<UserCalendarEntity> userEvents = userCalendarRepository.findAllByUsersAndProjectIsNullAndEventDateBetween(userInfo, startDateTime, endDateTime);
+
+        // 참여중인 프로젝트 조회 (Role이 CREATOR나 MEMBER인 경우, start 값이 true인 프로젝트)
+        List<ParticipationEntity> participations = participationRepository.findAllByUsersAndRoleInAndProjectStartTrue(userInfo, List.of(ProjectRole.CREATOR, ProjectRole.MEMBER));
+        List<ProjectEntity> projects = participations.stream()
+                .map(ParticipationEntity::getProject)
+                .toList();
+
+        // 참여중인 프로젝트 일정 조회
+        List<UserCalendarEntity> projectEvents = projects.stream()
+                .flatMap(project -> userCalendarRepository.findAllByProjectAndEventDateBetween(project, startDateTime, endDateTime).stream())
+                .toList();
 
     }
 }


### PR DESCRIPTION
1. 참여중인 프로젝트 조회
2. 해당 yyyy-MM에 해당하는 대학, 개인, 팀플 일정 정보 조회
3. 중복 코드 개선
4. 참여중인 팀플 일정 조회 jpa 쿼리 수정으로 성능 개선

close: #48 