### PR TITLE
feat: 캘린더 일정 추가 기능

### DIFF
--- a/src/main/java/com/muji_backend/kw_muji/calendar/controller/CalendarController.java
+++ b/src/main/java/com/muji_backend/kw_muji/calendar/controller/CalendarController.java
@@ -1,15 +1,13 @@
 package com.muji_backend.kw_muji.calendar.controller;
 
+import com.muji_backend.kw_muji.calendar.dto.request.CalendarRequestDto;
 import com.muji_backend.kw_muji.calendar.dto.response.CalendarResponseDto;
 import com.muji_backend.kw_muji.calendar.service.CalendarService;
 import com.muji_backend.kw_muji.common.entity.UserEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
@@ -21,11 +19,28 @@ public class CalendarController {
     private final CalendarService calendarService;
 
     @GetMapping("/{yearMonth}")
-    public ResponseEntity<?> getCalendar(@AuthenticationPrincipal UserEntity userInfo,
-                                         @PathVariable String yearMonth) {
+    public ResponseEntity<?> getCalendar(
+            @AuthenticationPrincipal UserEntity userInfo,
+            @PathVariable String yearMonth) {
+
         try {
             CalendarResponseDto response = calendarService.getCalendarEvents(userInfo, yearMonth);
             return ResponseEntity.ok().body(Map.of("code", 200, "data", response));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("code", 400, "message", e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(Map.of("code", 500, "message", e.getMessage()));
+        }
+    }
+
+    @PostMapping("/add")
+    public ResponseEntity<?> addCalendarEvent(
+            @AuthenticationPrincipal UserEntity userInfo,
+            @RequestBody CalendarRequestDto requestDto) {
+
+        try {
+            Long usercalendarId = calendarService.addCalendarEvent(userInfo, requestDto);
+            return ResponseEntity.ok().body(Map.of("code", 200, "usercalendarId", usercalendarId));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(Map.of("code", 400, "message", e.getMessage()));
         } catch (Exception e) {

--- a/src/main/java/com/muji_backend/kw_muji/calendar/dto/request/CalendarRequestDto.java
+++ b/src/main/java/com/muji_backend/kw_muji/calendar/dto/request/CalendarRequestDto.java
@@ -1,0 +1,15 @@
+package com.muji_backend.kw_muji.calendar.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+public class CalendarRequestDto {
+    private Long userId;
+    private Long projectId;           // 프로젝트 ID (null이면 개인 일정)
+    private String title;
+    private LocalDateTime eventDate;
+}

--- a/src/main/java/com/muji_backend/kw_muji/calendar/repository/ProjectRepository.java
+++ b/src/main/java/com/muji_backend/kw_muji/calendar/repository/ProjectRepository.java
@@ -1,0 +1,9 @@
+package com.muji_backend.kw_muji.calendar.repository;
+
+import com.muji_backend.kw_muji.common.entity.ProjectEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProjectRepository extends JpaRepository<ProjectEntity, Long> {
+}

--- a/src/main/java/com/muji_backend/kw_muji/calendar/service/CalendarService.java
+++ b/src/main/java/com/muji_backend/kw_muji/calendar/service/CalendarService.java
@@ -1,5 +1,6 @@
 package com.muji_backend.kw_muji.calendar.service;
 
+import com.muji_backend.kw_muji.calendar.dto.request.CalendarRequestDto;
 import com.muji_backend.kw_muji.calendar.dto.response.CalendarResponseDto;
 import com.muji_backend.kw_muji.calendar.repository.ParticipationRepository;
 import com.muji_backend.kw_muji.calendar.repository.UnivCalendarRepository;
@@ -73,9 +74,15 @@ public class CalendarService {
                 .build();
     }
 
+    // == Private Methods ==
+
     // 결과가 null인 경우 빈 리스트 반환
     private <T> List<T> safeList(Supplier<List<T>> queryFunction) {
         List<T> result = queryFunction.get();
         return result != null ? result : Collections.emptyList();
+    }
+
+    public Long addCalendarEvent(UserEntity userInfo, CalendarRequestDto requestDto) {
+
     }
 }


### PR DESCRIPTION
1. 캘린더 일정 추가 기능: projectId 유무로 개인일정 or 팀플일정 구분해서 저장

close: #49 