### PR TITLE
fix: 캘린더 dto 및 null 허용 수정(#152)

### DIFF
--- a/src/main/java/com/muji_backend/kw_muji/calendar/dto/request/CalendarRequestDto.java
+++ b/src/main/java/com/muji_backend/kw_muji/calendar/dto/request/CalendarRequestDto.java
@@ -1,14 +1,18 @@
 package com.muji_backend.kw_muji.calendar.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class CalendarRequestDto {
     private Long projectId;           // 프로젝트 ID (null이면 개인 일정)
     private String title;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime eventDate;
 }

--- a/src/main/java/com/muji_backend/kw_muji/calendar/dto/response/CalendarResponseDto.java
+++ b/src/main/java/com/muji_backend/kw_muji/calendar/dto/response/CalendarResponseDto.java
@@ -1,5 +1,6 @@
 package com.muji_backend.kw_muji.calendar.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,6 +13,7 @@ import java.util.List;
 @Data
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 public class CalendarResponseDto {
 
     private List<ProjectDto> projects;
@@ -46,6 +48,7 @@ public class CalendarResponseDto {
     public static class UserEventDto {
         private Long usercalendarId;
         private String title;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         private LocalDateTime eventDate;
     }
 
@@ -56,6 +59,7 @@ public class CalendarResponseDto {
         private Long projectId;
         private String name;
         private String title;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         private LocalDateTime eventDate;
     }
 }

--- a/src/main/java/com/muji_backend/kw_muji/common/entity/UserEventLinkEntity.java
+++ b/src/main/java/com/muji_backend/kw_muji/common/entity/UserEventLinkEntity.java
@@ -24,7 +24,7 @@ public class UserEventLinkEntity {
 
     // project : userEventLink = 1 : N
     @ManyToOne(targetEntity = ProjectEntity.class)
-    @JoinColumn(name = "projectId", nullable = false)
+    @JoinColumn(name = "projectId")
     private ProjectEntity project;
 
     // userCalendar : userEventLink = 1 : N


### PR DESCRIPTION
- LocalDateTime을 yyyy-MM-dd HH:mm:ss 로 고정
- 개인 일정 추가 시, null 값 입력 가능