### PR TITLE
fix: 공지사항 크롤링 빈 게시물 예외처리

### DIFF
--- a/src/main/java/com/muji_backend/kw_muji/kwnotice/controller/NoticeController.java
+++ b/src/main/java/com/muji_backend/kw_muji/kwnotice/controller/NoticeController.java
@@ -29,11 +29,9 @@ public class NoticeController {
             NoticeResponse notices = noticeService.getKwHomeNotices(page, searchVal, srCategoryId);
             return ResponseEntity.ok().body(Map.of("code", 200, "data", notices));
         } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(Map.of("code", 400, "data", e.getMessage()));
-        } catch (NullPointerException e) {
-            return ResponseEntity.status(500).body(Map.of("code", 500, "data", "처리 중에 문제가 발생했습니다. 잠시 후 다시 시도해주세요."));
-        } catch (RuntimeException e) {
-            return ResponseEntity.status(500).body(Map.of("code", 500, "data", e.getMessage()));
+            return ResponseEntity.badRequest().body(Map.of("code", 400, "message", e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(Map.of("code", 500, "message", e.getMessage()));
         }
     }
 }

--- a/src/main/java/com/muji_backend/kw_muji/kwnotice/util/NoticeUrlParser.java
+++ b/src/main/java/com/muji_backend/kw_muji/kwnotice/util/NoticeUrlParser.java
@@ -16,10 +16,17 @@ public class NoticeUrlParser {
     private static final String TITLE_SELECTOR = "div.board-text a";
     private static final String INFO_SELECTOR = "p.info";
     private static final String LAST_PAGE_SELECTOR = "a.ico-page.last";
+    private static final String EMPTY_NOTICE_SELECTOR = "li.list_none";
 
     public NoticeResponse parse(Document doc, String baseUrl) {
         List<NoticeResponse.Notice>  notices = new ArrayList<>();
         Elements elements = doc.select("div.board-list-box ul li");
+
+        // 게시물이 없는 경우 확인
+        Element emptyNoticeElement = doc.selectFirst(EMPTY_NOTICE_SELECTOR);
+        if (emptyNoticeElement != null && "등록된 글이 없습니다.".equals(emptyNoticeElement.text().trim())) {
+            return new NoticeResponse(notices, 1); // 빈 목록과 페이지 1 반환
+        }
 
         for (Element element : elements) {
             String category = element.select(CATEGORY_SELECTOR).text();

--- a/src/main/java/com/muji_backend/kw_muji/kwnotice/util/NoticeUrlParser.java
+++ b/src/main/java/com/muji_backend/kw_muji/kwnotice/util/NoticeUrlParser.java
@@ -18,43 +18,84 @@ public class NoticeUrlParser {
     private static final String LAST_PAGE_SELECTOR = "a.ico-page.last";
     private static final String EMPTY_NOTICE_SELECTOR = "li.list_none";
 
+    /**
+     * HTML 문서를 파싱하여 공지사항 목록과 최대 페이지 번호를 추출하는 메서드
+     *
+     * @param doc     공지사항 데이터가 포함된 HTML 문서
+     * @param baseUrl 공지사항 링크를 구성하기 위한 기본 URL
+     * @return 공지사항 목록과 최대 페이지 번호를 포함한 NoticeResponse 객체
+     */
     public NoticeResponse parse(Document doc, String baseUrl) {
-        List<NoticeResponse.Notice>  notices = new ArrayList<>();
+        try {
+            // 게시물이 없는 경우 처리
+            if (isEmptyNotice(doc)) {
+                return new NoticeResponse(new ArrayList<>(), 1); // 빈 목록과 기본 페이지 반환
+            }
+
+            // 공지사항 파싱
+            List<NoticeResponse.Notice> notices = parseNotices(doc, baseUrl);
+
+            // 최대 페이지 번호 추출
+            int maxPage = extractMaxPage(doc);
+
+            return new NoticeResponse(notices, maxPage);
+        } catch (Exception e) {
+            throw new RuntimeException("공지사항 데이터를 파싱하는 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    // == Private Methods ==
+
+    // 게시물이 없는지 확인
+    private boolean isEmptyNotice(Document doc) {
+        Element emptyNoticeElement = doc.selectFirst(EMPTY_NOTICE_SELECTOR);
+        return emptyNoticeElement != null && "등록된 글이 없습니다.".equals(emptyNoticeElement.text().trim());
+    }
+
+    // 공지사항 doc 파싱
+    private List<NoticeResponse.Notice> parseNotices(Document doc, String baseUrl) {
+        List<NoticeResponse.Notice> notices = new ArrayList<>();
         Elements elements = doc.select("div.board-list-box ul li");
 
-        // 게시물이 없는 경우 확인
-        Element emptyNoticeElement = doc.selectFirst(EMPTY_NOTICE_SELECTOR);
-        if (emptyNoticeElement != null && "등록된 글이 없습니다.".equals(emptyNoticeElement.text().trim())) {
-            return new NoticeResponse(notices, 1); // 빈 목록과 페이지 1 반환
-        }
-
         for (Element element : elements) {
-            String category = element.select(CATEGORY_SELECTOR).text();
-            String title = element.select(TITLE_SELECTOR).text()
-                    .replace(category, "").replace("신규게시글", "").replace("Attachment", "").trim();
-            String link = baseUrl + element.select(TITLE_SELECTOR).attr("href");
-            String info = element.select(INFO_SELECTOR).text();
-
-            String[] infoParts = info.split("\\|");
-            String views = infoParts[0].trim().replace("조회수 ", "");
-            String createdDate = infoParts[1].trim().replace("작성일 ", "");
-            String updatedDate = infoParts[2].trim().replace("수정일 ", "");
-            String team = infoParts[3].trim();
-
-            NoticeResponse.Notice notice = new NoticeResponse.Notice(
-                    category, title, link, views, createdDate, updatedDate, team
-            );
-            notices.add(notice);
+            notices.add(parseNoticeElement(element, baseUrl));
         }
+        return notices;
+    }
 
-        // 최대 페이지 추출
-        int maxPage = 1;
-        Element lastPageElement = doc.select(LAST_PAGE_SELECTOR).first();
+    // 개별 공지사항 요소를 파싱
+    private NoticeResponse.Notice parseNoticeElement(Element element, String baseUrl) {
+        String category = element.select(CATEGORY_SELECTOR).text();
+        String title = element.select(TITLE_SELECTOR).text()
+                .replace(category, "").replace("신규게시글", "").replace("Attachment", "").trim();
+        String link = baseUrl + element.select(TITLE_SELECTOR).attr("href");
+        String info = element.select(INFO_SELECTOR).text();
+
+        // 정보 문자열 파싱
+        String[] infoParts = info.split("\\|");
+        String views = parseInfoPart(infoParts, 0).replace("조회수 ", "");
+        String createdDate = parseInfoPart(infoParts, 1).replace("작성일 ", "");
+        String updatedDate = parseInfoPart(infoParts, 2).replace("수정일 ", "");
+        String team = parseInfoPart(infoParts, 3);
+
+        return new NoticeResponse.Notice(category, title, link, views, createdDate, updatedDate, team);
+    }
+
+    // 문자열 배열에서 특정 인덱스의 데이터를 추출
+    private String parseInfoPart(String[] infoParts, int index) {
+        if (index < infoParts.length) {
+            return infoParts[index].trim();
+        }
+        return ""; // 기본값
+    }
+
+    // 최대 페이지 번호를 추출
+    private int extractMaxPage(Document doc) {
+        Element lastPageElement = doc.selectFirst(LAST_PAGE_SELECTOR);
         if (lastPageElement != null) {
             String lastPageHref = lastPageElement.attr("href");
-            maxPage = Integer.parseInt(lastPageHref.split("tpage=")[1].split("&")[0]);
+            return Integer.parseInt(lastPageHref.split("tpage=")[1].split("&")[0]);
         }
-
-        return new NoticeResponse(notices, maxPage);
+        return 1; // 기본값
     }
 }


### PR DESCRIPTION
1. 공지사항을 크롤링할 때, 게시물이 없는 경우 index 에러가 발생
2. 따라서 게시물이 없는 경우, 예외처리를 진행

close: #163 